### PR TITLE
feat: generate rust lib inside this repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,15 @@ name = "moss-street-api-models"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-prost = "0.13.4"
-tokio = {version = "1.42.0", features = ['full']}
-tonic = "0.12.3"
-tonic-reflection = "0.12.3"
-tonic-web = "0.12.3"
-tower-http = "0.6.2"
+[lib]
+name = "rust_models"
+path = "src/lib.rs"
 
 [build-dependencies]
 tonic-build = "0.12.3"
 anyhow = "1.0.95"
+
+[dependencies]
+tonic = "0.12.3"
+prost = "0.13.4"
+prost-types = "0.13.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod common {
+    tonic::include_proto!("common");
+    tonic::include_proto!("authorization");
+
+    pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("moss-street");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,2 +1,0 @@
-/// A blank main function to get cargo to play nicely with the build.rs file
-fn main() {}


### PR DESCRIPTION
the problem here was that the generated code couldn't get picked up by the backend so we can "generate" that code into lib.rs and export that lib to be imported to our other crates. This will allow us to use the other code in other crates. We can also drop the dependency on tonic-build in other crates because of this