### PR TITLE
feat!: change user id to i32

### DIFF
--- a/protos/common.proto
+++ b/protos/common.proto
@@ -11,7 +11,7 @@ message Token {
 }
 
 message User {
-  uint64 uuid = 1;
+  int32 uuid = 1;
   string username = 2;
   Token token = 3;
   google.protobuf.Timestamp creation_date = 4;


### PR DESCRIPTION
apparently it's better practice to use i32 for user ids instead of u32 according to diesel. Changing the user id to make serialization/deserialization of those easier.